### PR TITLE
bugfix: Fix for when operation ID is null.

### DIFF
--- a/src/Parsers/OpenApiParser.php
+++ b/src/Parsers/OpenApiParser.php
@@ -66,7 +66,7 @@ class OpenApiParser implements Parser
     protected function parseEndpoint(Operation $operation, $pathParams, string $path, string $method): ?Endpoint
     {
         return new Endpoint(
-            name: trim($operation->operationId) ?: trim($operation->summary),
+            name:  trim($operation->operationId ?: $operation->summary ?: ''),
             method: Method::parse($method),
             pathSegments: Str::of($path)->replace('{', ':')->remove('}')->trim('/')->explode('/')->toArray(),
             collection: $operation->tags[0] ?? null, // In the real-world, people USUALLY only use one tag...


### PR DESCRIPTION
When operation ID is null, a warning message is shown as null cannot be passed to trim.

This change allows operation ID and summary to be checked for a value before defaulting to an empty string.