### PR TITLE
Feature: Headers support for OpenApi and Postman parsers

### DIFF
--- a/src/Contracts/Parser.php
+++ b/src/Contracts/Parser.php
@@ -7,4 +7,6 @@ use Crescat\SaloonSdkGenerator\Data\Generator\ApiSpecification;
 interface Parser
 {
     public function parse(): ApiSpecification;
+
+    public function getExcludedHeaders(): array;
 }

--- a/src/Data/Generator/Endpoint.php
+++ b/src/Data/Generator/Endpoint.php
@@ -8,6 +8,7 @@ class Endpoint
      * @param  Parameter[]  $queryParameters
      * @param  Parameter[]  $pathParameters
      * @param  Parameter[]  $bodyParameters
+     * @param  Parameter[]  $headerParameters
      */
     public function __construct(
         public string $name,
@@ -22,6 +23,7 @@ class Endpoint
         public array $queryParameters = [],
         public array $pathParameters = [],
         public array $bodyParameters = [],
+        public array $headerParameters = [],
     ) {
     }
 
@@ -34,6 +36,7 @@ class Endpoint
             ...$this->pathParameters,
             ...$this->bodyParameters,
             ...$this->queryParameters,
+            ...$this->headerParameters,
         ];
     }
 

--- a/src/Generators/RequestGenerator.php
+++ b/src/Generators/RequestGenerator.php
@@ -120,6 +120,20 @@ class RequestGenerator extends Generator
             MethodGeneratorHelper::generateArrayReturnMethod($classType, 'defaultQuery', $queryParams, withArrayFilterWrapper: true);
         }
 
+        // Priority 4. - Header Parameters
+        if (! empty($endpoint->headerParameters)) {
+            $headerParams = collect($endpoint->headerParameters)
+                ->reject(fn (Parameter $parameter) => in_array($parameter->name, $this->config->ignoredQueryParams))
+                ->values()
+                ->toArray();
+
+            foreach ($headerParams as $headerParam) {
+                MethodGeneratorHelper::addParameterAsPromotedProperty($classConstructor, $headerParam);
+            }
+
+            MethodGeneratorHelper::generateArrayReturnMethod($classType, 'defaultHeaders', $headerParams, withArrayFilterWrapper: true);
+        }
+
         $namespace
             ->addUse(SaloonHttpMethod::class)
             ->addUse(DateTime::class)

--- a/src/Parsers/OpenApiParser.php
+++ b/src/Parsers/OpenApiParser.php
@@ -76,6 +76,7 @@ class OpenApiParser implements Parser
             // TODO: Check if this differs between spec versions
             pathParameters: $pathParams + $this->mapParams($operation->parameters, 'path'),
             bodyParameters: [], // TODO: implement "definition" parsing
+            headerParameters: $this->mapParams($operation->parameters, 'header'),
         );
     }
 

--- a/src/Parsers/PostmanCollectionParser.php
+++ b/src/Parsers/PostmanCollectionParser.php
@@ -156,14 +156,20 @@ class PostmanCollectionParser implements Parser
     {
         return collect($item->request->header)
             ->map(function ($param) {
-                if (! Arr::get($param, 'key')) {
+                $headerName = Arr::get($param, 'key');
+                if (! $headerName) {
+                    return null;
+                }
+
+                // Exclude headers already handled in Connectors
+                if (in_array($headerName, ['Authorization', 'Content-Type', 'Accept'])) {
                     return null;
                 }
 
                 return new Parameter(
                     type: 'string',
                     nullable: false,
-                    name: Arr::get($param, 'key'),
+                    name: $headerName,
                 );
             })
             ->filter()

--- a/src/Parsers/PostmanCollectionParser.php
+++ b/src/Parsers/PostmanCollectionParser.php
@@ -80,7 +80,7 @@ class PostmanCollectionParser implements Parser
             queryParameters: $this->parseQueryParameters($item),
             pathParameters: $this->parsePathParameters($item),
             bodyParameters: $this->parseBodyParameters($item),
-
+            headerParameters: $this->parseHeaderParameters($item),
         );
     }
 
@@ -149,6 +149,26 @@ class PostmanCollectionParser implements Parser
                     name: $param,
                 );
             })
+            ->toArray();
+    }
+
+    protected function parseHeaderParameters(Item $item): array
+    {
+        return collect($item->request->header)
+//            ->filter(fn ($segment) => Str::startsWith($segment, ':'))
+            ->map(function ($param) {
+                if (! Arr::get($param, 'key')) {
+                    return null;
+                }
+
+                return new Parameter(
+                    type: 'string',
+                    nullable: false,
+                    name: Arr::get($param, 'key'),
+                );
+            })
+            ->filter()
+            ->values()
             ->toArray();
     }
 }

--- a/src/Parsers/PostmanCollectionParser.php
+++ b/src/Parsers/PostmanCollectionParser.php
@@ -155,7 +155,6 @@ class PostmanCollectionParser implements Parser
     protected function parseHeaderParameters(Item $item): array
     {
         return collect($item->request->header)
-//            ->filter(fn ($segment) => Str::startsWith($segment, ':'))
             ->map(function ($param) {
                 if (! Arr::get($param, 'key')) {
                     return null;

--- a/src/Parsers/PostmanCollectionParser.php
+++ b/src/Parsers/PostmanCollectionParser.php
@@ -162,7 +162,7 @@ class PostmanCollectionParser implements Parser
                 }
 
                 // Exclude headers already handled in Connectors
-                if (in_array($headerName, ['Authorization', 'Content-Type', 'Accept'])) {
+                if (in_array($headerName, $this->getExcludedHeaders())) {
                     return null;
                 }
 
@@ -175,5 +175,10 @@ class PostmanCollectionParser implements Parser
             ->filter()
             ->values()
             ->toArray();
+    }
+
+    public function getExcludedHeaders(): array
+    {
+        return ['Authorization', 'Content-Type', 'Accept'];
     }
 }


### PR DESCRIPTION
Based on your guidance in #9 I poked around with getting headers working for the OpenApiParser. After a little more digging and using a postman collection for the same API I'm building for, I added header parsing to the Postman parser too.

While I see named parameters are in use here, juuuust to be safe I've added the header parameter arrays to the end of the argument list instead of anywhere else.

Let me know what you think, or if you have any issues with any API specs/collections you have?