### PR TITLE
feat: OpenAPI security scheme parsing and connector auth for API keys

### DIFF
--- a/src/Data/Generator/ApiSpecification.php
+++ b/src/Data/Generator/ApiSpecification.php
@@ -5,17 +5,21 @@ namespace Crescat\SaloonSdkGenerator\Data\Generator;
 class ApiSpecification
 {
     /**
-     * @param  ?string  $name
-     * @param  ?string  $description
-     * @param  ?string  $baseUrl
-     * @param  Endpoint[]  $endpoints
+     * @param ?string $name
+     * @param ?string $description
+     * @param ?string $baseUrl
+     * @param ?SecurityRequirement[] $securityRequirements
+     * @param ?Components $components
+     * @param Endpoint[] $endpoints
      */
     public function __construct(
-        public ?string $name,
-        public ?string $description,
-        public ?string $baseUrl,
-        public array $endpoints,
-
-    ) {
+        public ?string     $name,
+        public ?string     $description,
+        public ?string     $baseUrl,
+        public ?array      $securityRequirements,
+        public ?Components $components,
+        public array       $endpoints,
+    )
+    {
     }
 }

--- a/src/Data/Generator/ApiSpecification.php
+++ b/src/Data/Generator/ApiSpecification.php
@@ -7,7 +7,7 @@ class ApiSpecification
     /**
      * @param ?string $name
      * @param ?string $description
-     * @param ?string $baseUrl
+     * @param ?BaseUrl $baseUrl
      * @param ?SecurityRequirement[] $securityRequirements
      * @param ?Components $components
      * @param Endpoint[] $endpoints
@@ -15,7 +15,7 @@ class ApiSpecification
     public function __construct(
         public ?string     $name,
         public ?string     $description,
-        public ?string     $baseUrl,
+        public ?BaseUrl    $baseUrl,
         public ?array      $securityRequirements,
         public ?Components $components,
         public array       $endpoints,

--- a/src/Data/Generator/BaseUrl.php
+++ b/src/Data/Generator/BaseUrl.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Crescat\SaloonSdkGenerator\Data\Generator;
+
+class BaseUrl
+{
+    /**
+     * @param string $url
+     * @param ServerParameter[] $parameters
+     */
+    public function __construct(
+        public readonly string $url,
+        public readonly array  $parameters = [],
+    )
+    {
+    }
+}

--- a/src/Data/Generator/Components.php
+++ b/src/Data/Generator/Components.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Crescat\SaloonSdkGenerator\Data\Generator;
+
+class Components
+{
+
+    /**
+     * @param array $schemas
+     * @param array $responses
+     * @param array $parameters
+     * @param array $examples
+     * @param array $requestBodies
+     * @param array $headers
+     * @param SecurityScheme[] $securitySchemes
+     * @param array $links
+     * @param array $callbacks
+     * @param array $pathItems
+     */
+    public function __construct(
+        public readonly array $schemas = [],
+        public readonly array $responses = [],
+        public readonly array $parameters = [],
+        public readonly array $examples = [],
+        public readonly array $requestBodies = [],
+        public readonly array $headers = [],
+        public readonly array $securitySchemes = [],
+        public readonly array $links = [],
+        public readonly array $callbacks = [],
+        public readonly array $pathItems = []
+    )
+    {
+    }
+}

--- a/src/Data/Generator/SecurityRequirement.php
+++ b/src/Data/Generator/SecurityRequirement.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Crescat\SaloonSdkGenerator\Data\Generator;
+
+class SecurityRequirement
+{
+
+    /**
+     * @param string|null $name
+     * @param string[] $scopes
+     */
+    public function __construct(
+        public readonly ?string $name,
+        public readonly array   $scopes = [],
+    )
+    {
+    }
+}

--- a/src/Data/Generator/SecurityScheme.php
+++ b/src/Data/Generator/SecurityScheme.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Crescat\SaloonSdkGenerator\Data\Generator;
+
+class SecurityScheme
+{
+    const TYPE_API_KEY = 'apiKey';
+    const TYPE_HTTP = 'http';
+    const TYPE_MUTUAL_TLS = 'mutualTLS';
+    const TYPE_OAUTH2 = 'oauth2';
+    const TYPE_OPEN_ID_CONNECT = 'openIdConnect';
+
+    const IN_QUERY = 'query';
+    const IN_HEADER = 'header';
+    const IN_COOKIE = 'cookie';
+
+    public function __construct(
+        public readonly string  $type,
+        public readonly ?string $name = null,
+        public readonly ?string $in = null,
+        public readonly ?string $scheme = null,
+        public readonly ?string $description = null,
+        public readonly ?string $bearerFormat = null,
+        public readonly ?object $flows = null,
+        public readonly ?string $openIdConnectUrl = null
+    )
+    {
+    }
+}

--- a/src/Data/Generator/ServerParameter.php
+++ b/src/Data/Generator/ServerParameter.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Crescat\SaloonSdkGenerator\Data\Generator;
+
+class ServerParameter
+{
+    public function __construct(
+        public readonly string  $name,
+        public readonly string  $default,
+        public readonly ?string $description = null
+    )
+    {
+    }
+}

--- a/src/Helpers/TemplateHelper.php
+++ b/src/Helpers/TemplateHelper.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Crescat\SaloonSdkGenerator\Helpers;
+
+class TemplateHelper
+{
+    public static function render(string $template, array $variables = []): string
+    {
+        $result = preg_replace_callback(
+            '/{(.+?)}/',
+            function ($matches) use ($variables) {
+                return $variables[$matches[1]];
+            },
+            $template
+        );
+
+        return $result ?? $template;
+    }
+}

--- a/src/Parsers/PostmanCollectionParser.php
+++ b/src/Parsers/PostmanCollectionParser.php
@@ -5,7 +5,6 @@ namespace Crescat\SaloonSdkGenerator\Parsers;
 use Crescat\SaloonSdkGenerator\Contracts\Parser;
 use Crescat\SaloonSdkGenerator\Data\Generator\ApiSpecification;
 use Crescat\SaloonSdkGenerator\Data\Generator\BaseUrl;
-use Crescat\SaloonSdkGenerator\Data\Generator\Components;
 use Crescat\SaloonSdkGenerator\Data\Generator\Endpoint;
 use Crescat\SaloonSdkGenerator\Data\Generator\Method;
 use Crescat\SaloonSdkGenerator\Data\Generator\Parameter;
@@ -34,7 +33,6 @@ class PostmanCollectionParser implements Parser
 
     public function parse(): ApiSpecification
     {
-
         $baseUrlVariable = collect($this->postmanCollection->variables)->firstWhere(
             fn(Variable $var) => $var->key == 'baseUrl'
         );

--- a/tests/Feature/InspireCommandTest.php
+++ b/tests/Feature/InspireCommandTest.php
@@ -1,5 +1,0 @@
-<?php
-
-it('inspires artisans', function () {
-    $this->artisan('inspire')->assertExitCode(0);
-});

--- a/tests/Samples/bigcommerce/abandoned_carts.v3.yml
+++ b/tests/Samples/bigcommerce/abandoned_carts.v3.yml
@@ -1,0 +1,521 @@
+openapi: '3.0.0'
+info:
+  version: ''
+  title: Abandoned Carts
+  description: |-
+    Use `/abandoned-carts/{token}` on headless storefronts to retrieve the `cart_id` using the abandoned cart `token` passed to the storefront when a shopper clicks an abandoned cart email link. Once the cart ID has been retrieved, your application can use it to fetch and display information about the cart to the shopper using the REST Storefront API, the REST Management API, or the GraphQL Storefront API.
+  termsOfService: 'https://www.bigcommerce.com/terms'
+  contact:
+    name: BigCommerce
+    url: 'https://www.bigcommerce.com'
+    email: support@bigcommerce.com
+servers:
+  - url: 'https://api.bigcommerce.com/stores/{store_hash}/v3'
+    variables:
+      store_hash:
+        default: store_hash
+        description: Permanent ID of the BigCommerce store.
+    description: BigCommerce API Gateway
+security:
+  - X-Auth-Token: []
+tags:
+  - name: Abandoned Carts
+  - name: Abandoned Cart Settings
+  - name: Abandoned Carts Settings
+paths:
+  '/abandoned-carts/settings':
+    get:
+      summary: Get Global Abandoned Cart Settings
+      description: Returns the global abandoned cart settings of a store.
+      operationId: getGlobalAbandonedCartSettings
+      tags:
+        - Abandoned Cart Settings
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GlobalAbandonedCartSettingsResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      parameters: []
+    put:
+      summary: Update Global Abandoned Cart Settings
+      description: Updates the global abandoned cart settings of a store.
+      operationId: UpdateGlobalAbandonedCartSettings
+      tags:
+        - Abandoned Carts Settings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GlobalAbandonedCartSettingsRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GlobalAbandonedCartSettingsResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      parameters:
+        - $ref: '#/components/parameters/ContentType'
+    parameters:
+      
+      - $ref: '#/components/parameters/Accept'
+  '/abandoned-carts/settings/channels/{channel_id}':
+    get:
+      summary: Get Channel Abandoned Cart Settings
+      description: Returns the per-channel overrides for the abandoned cart settings of a store.
+      operationId: getChannelAbandonedCartSettings
+      tags:
+        - Abandoned Carts Settings
+      parameters:
+        - name: channel_id
+          description: The channel ID of the settings overrides
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelAbandonedCartSettingsResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    put:
+      summary: Update Channel Abandoned Cart Settings
+      description: |-
+        Updates the per-channel overrides for the abandoned cart settings of a store.
+
+        #### OAuth Scopes
+        | UI Name                                      | Permission | Parameter                                     |
+        |----------------------------------------------|------------|-----------------------------------------------|     
+        | Information & Settings                       | modify     | `store_v2_information`                        |
+      operationId: UpdateChannelAbandonedCartSettings
+      tags:
+        - Abandoned Carts Settings
+      parameters:
+        - $ref: '#/components/parameters/ContentType'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChannelAbandonedCartSettingsRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelAbandonedCartSettingsResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      security: []
+    parameters:
+      - $ref: '#/components/parameters/Accept'
+      - name: channel_id
+        description: The channel ID of the settings overrides
+        in: path
+        required: true
+        schema:
+          type: integer
+  '/abandoned-carts/{token}':
+    get:
+      responses:
+        '200':
+          $ref: '#/components/responses/abandonedCart_Resp'
+        '400':
+          $ref: '#/components/responses/400_BadRequest'
+        '404':
+          $ref: '#/components/responses/404_NotFound'
+        '422':
+          $ref: '#/components/responses/422_UnprocessableEntity'
+        '502':
+          $ref: '#/components/responses/502_GatewayError'
+        '503':
+          $ref: '#/components/responses/503_ServiceUnavailable'
+        '504':
+          $ref: '#/components/responses/504_GatewayTimeout'
+        default:
+          description: ''
+      summary: Get an Abandoned Cart
+      description: |-
+        Returns the `cart_id` corresponding to the abandoned cart `{token}` passed in.
+
+        **Usage Notes**:
+        * `{token}` is the token in the query string of the abandoned cart link found in abandoned cart email notifications to shoppers
+      operationId: getAbandonedCarts
+      tags:
+        - Abandoned Carts
+    parameters:
+      - name: token
+        in: path
+        required: true
+        description: |-
+          Unique cart `UUID`.
+
+          Unique cart `UUID` token that is generated for abandoned cart emails.
+        schema:
+          type: string
+      
+      - $ref: '#/components/parameters/Accept'
+components:
+  parameters:
+    Accept:
+      name: Accept
+      in: header
+      required: true
+      description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the response body.'
+      schema:
+        type: string
+        default: 'application/json'
+    ContentType:
+      name: Content-Type
+      in: header
+      required: true
+      description: 'The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body.'
+      schema:
+        type: string
+        default: 'application/json'
+  responses:
+    502_GatewayError:
+      description: 'If something happens during the request that causes it to fail, a 502 response will be returned. A new request should be made; however, it could fail.'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error_Full'
+          examples:
+            response:
+              value:
+                status: 502
+                title: A login URL could not be generated. Please try another request.
+                type: /api-docs/getting-started/api-status-codes
+    504_GatewayTimeout:
+      description: 'If this occurs, you should retry the request. Typically retrying the request several times will result in a successful request; However, if you are unable to successfully make a request, please check the BigCommerce system status [here](https://status.bigcommerce.com/). A service is likely down and the request will need to be made again when it is back up (in several hours usually)'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/errorDetailed_Full'
+          examples:
+            response:
+              value:
+                status: 504
+                title: Gateway Timeout
+                type: /api-docs/getting-started/api-status-codes
+                errors: {}
+    403_Unauthorized:
+      description: ''
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error_Full'
+          examples:
+            response:
+              value:
+                status: 403
+                title: Unauthorized Access. You do not have permission to make this request.
+                type: /api-docs/getting-started/api-status-codes
+    400_BadRequest:
+      description: |-
+        Malformed request syntax. Typically need to fix the JSON
+        Body to resend successfully.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error_Full'
+          examples:
+            response:
+              value:
+                status: 400
+                title: Input is invalid.
+                type: /api-docs/getting-started/api-status-codes
+    404_NotFound:
+      description: 'If the requested account resource is not found for the franchise, return a 404 Not Found.'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error_Full'
+          examples:
+            response:
+              value:
+                status: 404
+                title: 'Account with {id} not found'
+                type: /api-docs/getting-started/api-status-codes
+    422_UnprocessableEntity:
+      description: This occurs when missing or unacceptable data is passed for one or more fields. Please correct the values for the fields listed in the errors object.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/errorDetailed_Full'
+          examples:
+            response:
+              value:
+                status: 422
+                title: JSON data is missing or invalid
+                type: /api-docs/getting-started/api-status-codes
+                errors:
+                  name: error.expected.jsstring
+                  primary_contact.district: error.expected.jsstring.
+    503_ServiceUnavailable:
+      description: 'If this occurs, you should retry the request. If you are unable to successfully make a request, please check the BigCommerce system status [here](https://status.bigcommerce.com/). A service is likely down and the request will need to be made again when it is back up (in several hours usually)'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/error_Full'
+          examples:
+            response:
+              value:
+                status: 503
+                title: Service Unavailable
+                type: /api-docs/getting-started/api-status-codes
+    abandonedCart_Resp:
+      description: Returned on `GET` requests to `/abandoned_carts`.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/components/schemas/abandonedCartInfo_Full'
+              meta:
+                $ref: '#/components/schemas/metaEmpty_Full'
+  securitySchemes:
+    X-Auth-Token:
+      name: X-Auth-Token
+      description: |-
+        ### OAuth scopes
+
+        | UI Name | Permission | Parameter |
+        |:--------|:-----------|:----------|
+        | Information & Settings  | read-only  | `store_v2_information_read_only`|
+        | Information & Settings  | modify     | `store_v2_information`          |
+
+        ### Authentication header
+
+        | Header | Argument | Description |
+        |:-------|:---------|:------------|
+        | `X-Auth-Token` | `access_token` | For more about API accounts that generate `access_token`s, see our [Guide to API Accounts](/api-docs/getting-started/api-accounts). |
+        
+        ### Further reading
+
+        For example requests and more information about authenticating BigCommerce APIs, see [Authentication and Example Requests](/api-docs/getting-started/authentication#x-auth-token-header-example-requests).
+        
+        For more about BigCommerce OAuth scopes, see our [Guide to API Accounts](/api-docs/getting-started/api-accounts#oauth-scopes).
+        
+        For a list of API status codes, see [API Status Codes](/api-docs/getting-started/api-status-codes).
+      type: apiKey
+      in: header
+  schemas:
+    metaEmpty_Full:
+      title: Response meta
+      type: object
+      properties: {}
+      additionalProperties: true
+      description: Response metadata.
+    error_Full:
+      type: object
+      title: error_Full
+      properties:
+        status:
+          description: |
+            The HTTP status code.
+          type: integer
+        title:
+          description: |
+            The error title describing the particular error.
+          type: string
+        type:
+          type: string
+      x-internal: false
+    errorDetailed_Full:
+      type: object
+      properties:
+        errors:
+          type: object
+          additionalProperties:
+            type: string
+          title: DetailedErrors
+      title: errorDetailed_Full
+      x-internal: false
+    abandonedCartInfo_Full:
+      type: object
+      title: abandonedCartInfo_Full
+      properties:
+        cart_id:
+          type: string
+          description: The `cart_id` of the abandoned cart. Can be used to display the abandoned cart to the customer using storefront cart or
+      x-internal: false
+    AbandonedCartSettings:
+      description: Represents all settings related to the abandoned cart functionality of a store
+      type: object
+      x-tags:
+        - Models
+      properties:
+        enable_notification:
+          description: Indicates whether or not abandoned cart notification is on
+          type: boolean
+        email_customer_until_cart_is_recovered:
+          description: Indicates whether or not a customer should continue to receive abandoned cart emails until their cart is recovered
+          type: boolean
+        marketing_emails_require_customer_consent:
+          description: Indicates whether or not a customer should receive abandoned cart emails based on their consent. By default customers will not receive emails.
+          type: boolean
+        email_merchant_when_cart_is_converted:
+          description: Indicates whether or not a merchant should receive a notification email when a cart is converted into an order
+          type: boolean
+        email_merchant_when_cart_is_abandoned:
+          description: Indicates whether or not a merchant should receive a notification email when a cart is abandoned
+          type: boolean
+        merchant_email_address:
+          description: The email address for receiving merchant notifications
+          type: string
+          format: email
+        merchant_abandoned_cart_email_frequency_type:
+          description: 'Indicates whether to send an email for every abandoned cart, or to send a digest email after X number of abandoned carts'
+          type: string
+          enum:
+            - digest
+            - individual
+        merchant_abandoned_cart_digest_email_frequency:
+          description: The number of abandoned carts to accumulate before a digest email is sent to a merchant
+          type: integer
+          minimum: 2
+          maximum: 1000
+    ChannelAbandonedCartSettings:
+      description: Represents all settings overrides related to the abandoned cart functionality of a store for a channel
+      type: object
+      x-tags:
+        - Models
+      properties:
+        enable_notification:
+          description: 'Indicates whether or not abandoned cart notification is on. If it is null, it means there is no override for the specified channel.'
+          type: boolean
+          nullable: true
+        email_customer_until_cart_is_recovered:
+          description: 'Indicates whether or not a customer should continue to receive abandoned cart emails until their cart is recovered. If it is null, it means there is no override for the specified channel.'
+          type: boolean
+          nullable: true
+        marketing_emails_require_customer_consent:
+          description: 'Indicates whether or not a customer should receive abandoned cart emails based on their consent. If it is null, it means there is no override for the specified channel. By default customers will not receive emails.'
+          type: boolean
+          nullable: true
+        email_merchant_when_cart_is_converted:
+          description: 'Indicates whether or not a merchant should receive a notification email when a cart is converted into an order. If it is null, it means there is no override for the specified channel.'
+          type: boolean
+          nullable: true
+        email_merchant_when_cart_is_abandoned:
+          description: 'Indicates whether or not a merchant should receive a notification email when a cart is abandoned. If it is null, it means there is no override for the specified channel.'
+          type: boolean
+          nullable: true
+        merchant_email_address:
+          description: 'The email address for receiving merchant notifications. If it is null, it means there is no override for the specified channel.'
+          type: string
+          format: email
+          nullable: true
+        merchant_abandoned_cart_email_frequency_type:
+          description: 'Indicates whether to send an email for every abandoned cart or to send a digest email after X number of abandoned carts. If it is null, it means there is no override for the specified channel.'
+          type: string
+          enum:
+            - digest
+            - individual
+          nullable: true
+        merchant_abandoned_cart_digest_email_frequency:
+          description: 'The number of abandoned carts to accumulate before a digest email is sent to a merchant. If it is null, it means there is no override for the specified channel.'
+          type: integer
+          minimum: 2
+          maximum: 1000
+          nullable: true
+    ChannelAbandonedCartSettingsRequest:
+      allOf:
+        - $ref: '#/components/schemas/ChannelAbandonedCartSettings'
+        - description: The request object for updating the abandoned cart settings overrides of a store for a channel
+      x-tags:
+        - Models
+    ChannelAbandonedCartSettingsResponse:
+      description: The response object of abandoned cart settings overrides for a channel
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/ChannelAbandonedCartSettings'
+        meta:
+          $ref: '#/components/schemas/metaEmpty_Full'
+      x-tags:
+        - Models
+    GlobalAbandonedCartSettingsRequest:
+      allOf:
+        - $ref: '#/components/schemas/AbandonedCartSettings'
+        - description: The request object for updating the abandoned cart settings of a store at the global level
+          required:
+            - enabled
+            - email_customer_until_cart_is_recovered
+            - marketing_emails_require_customer_consent
+            - email_merchant_when_cart_is_converted
+            - email_merchant_when_cart_is_abandoned
+            - merchant_email_address
+            - merchant_abandoned_cart_email_frequency_type
+            - merchant_abandoned_cart_digest_email_frequency
+      x-tags:
+        - Models
+    GlobalAbandonedCartSettingsResponse:
+      description: The response object of abandoned cart settings at the global level
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/AbandonedCartSettings'
+        meta:
+          $ref: '#/components/schemas/metaEmpty_Full'
+      x-tags:
+        - Models
+    ErrorResponse:
+      description: The response object containing details of an error
+      type: object
+      properties:
+        status:
+          type: integer
+        title:
+          type: string
+        type:
+          type: string
+        instance:
+          type: string
+        errors:
+          type: object
+      x-tags:
+        - Models
+

--- a/tests/Unit/Generators/ConnectorGeneratorTest.php
+++ b/tests/Unit/Generators/ConnectorGeneratorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Crescat\SaloonSdkGenerator\Data\Generator\ApiSpecification;
+use Crescat\SaloonSdkGenerator\Data\Generator\Components;
+use Crescat\SaloonSdkGenerator\Data\Generator\Config;
+use Crescat\SaloonSdkGenerator\Data\Generator\SecurityRequirement;
+use Crescat\SaloonSdkGenerator\Data\Generator\SecurityScheme;
+use Crescat\SaloonSdkGenerator\Generators\ConnectorGenerator;
+
+test('Constructor', function () {
+
+    $generator = new ConnectorGenerator(new Config('MyConnector', 'VendorName'));
+
+    $apiSpec = new ApiSpecification(
+        name: 'ApiName',
+        description: 'Example API',
+        baseUrl: 'https://api.example.com/v1/',
+        securityRequirements: [
+            new SecurityRequirement('X-Auth-Token'),
+        ],
+        components: new Components(
+            securitySchemes: [
+                new SecurityScheme(
+                    type: 'apiKey',
+                    name: 'X-Auth-Token',
+                    in: 'header',
+                )
+            ]
+        ),
+        endpoints: []
+    );
+
+    $phpFile = $generator->generate($apiSpec);
+
+    $class = $phpFile->getNamespaces()['VendorName']->getClasses()['MyConnector'];
+    expect($class)->toBeInstanceOf(\Nette\PhpGenerator\ClassType::class);
+
+    $constructor = $class->getMethods()['__construct'];
+    expect($constructor)->toBeInstanceOf(\Nette\PhpGenerator\Method::class)
+        ->and($constructor->getParameters())->toHaveCount(1)
+        ->and($constructor->getBody())->toBe("\$this->withTokenAuth(\$authToken);\n");
+
+    $authTokenParam = $constructor->getParameter('authToken');
+    expect($authTokenParam)->not->toBeNull()
+        ->and($authTokenParam->getType())->toBe('string')
+        ->and($authTokenParam->isNullable())->toBeFalse();
+});

--- a/tests/Unit/Generators/ConnectorGeneratorTest.php
+++ b/tests/Unit/Generators/ConnectorGeneratorTest.php
@@ -1,20 +1,59 @@
 <?php
 
 use Crescat\SaloonSdkGenerator\Data\Generator\ApiSpecification;
+use Crescat\SaloonSdkGenerator\Data\Generator\BaseUrl;
 use Crescat\SaloonSdkGenerator\Data\Generator\Components;
 use Crescat\SaloonSdkGenerator\Data\Generator\Config;
 use Crescat\SaloonSdkGenerator\Data\Generator\SecurityRequirement;
 use Crescat\SaloonSdkGenerator\Data\Generator\SecurityScheme;
+use Crescat\SaloonSdkGenerator\Data\Generator\ServerParameter;
 use Crescat\SaloonSdkGenerator\Generators\ConnectorGenerator;
 
 test('Constructor', function () {
 
     $generator = new ConnectorGenerator(new Config('MyConnector', 'VendorName'));
+    $apiSpec = getApiSpec();
+    $phpFile = $generator->generate($apiSpec);
+    $class = $phpFile->getNamespaces()['VendorName']->getClasses()['MyConnector'];
 
-    $apiSpec = new ApiSpecification(
+    expect($class)->toBeInstanceOf(\Nette\PhpGenerator\ClassType::class);
+
+    $constructor = $class->getMethods()['__construct'];
+    expect($constructor)->toBeInstanceOf(\Nette\PhpGenerator\Method::class)
+        ->and($constructor->getParameters())->toHaveCount(2)
+        ->and($constructor->getBody())->toBe("\$this->withTokenAuth(\$authToken);\n");
+
+    $regionParam = $constructor->getParameter('region');
+    expect($regionParam)->not->toBeNull()
+        ->and($regionParam->getType())->toBe('string')
+        ->and($regionParam->isNullable())->toBeFalse();
+
+    $authTokenParam = $constructor->getParameter('authToken');
+    expect($authTokenParam)->not->toBeNull()
+        ->and($authTokenParam->getType())->toBe('string')
+        ->and($authTokenParam->isNullable())->toBeFalse();
+});
+
+test('Resolve Base URL', function () {
+    $generator = new ConnectorGenerator(new Config('MyConnector', 'VendorName'));
+    $apiSpec = getApiSpec();
+    $phpFile = $generator->generate($apiSpec);
+    $class = $phpFile->getNamespaces()['VendorName']->getClasses()['MyConnector'];
+
+    $resolveBaseUrl = $class->getMethods()['resolveBaseUrl'];
+    expect($resolveBaseUrl->getParameters())->toBeEmpty()
+        ->and($resolveBaseUrl->getBody())->toBe("return \"https://api-{\$this->region}.example.com/v1/\";");
+});
+
+function getApiSpec(): ApiSpecification
+{
+    return new ApiSpecification(
         name: 'ApiName',
         description: 'Example API',
-        baseUrl: 'https://api.example.com/v1/',
+        baseUrl: new BaseUrl(
+            'https://api-{region}.example.com/v1/',
+            [new ServerParameter('region', 'eu')]
+        ),
         securityRequirements: [
             new SecurityRequirement('X-Auth-Token'),
         ],
@@ -29,19 +68,4 @@ test('Constructor', function () {
         ),
         endpoints: []
     );
-
-    $phpFile = $generator->generate($apiSpec);
-
-    $class = $phpFile->getNamespaces()['VendorName']->getClasses()['MyConnector'];
-    expect($class)->toBeInstanceOf(\Nette\PhpGenerator\ClassType::class);
-
-    $constructor = $class->getMethods()['__construct'];
-    expect($constructor)->toBeInstanceOf(\Nette\PhpGenerator\Method::class)
-        ->and($constructor->getParameters())->toHaveCount(1)
-        ->and($constructor->getBody())->toBe("\$this->withTokenAuth(\$authToken);\n");
-
-    $authTokenParam = $constructor->getParameter('authToken');
-    expect($authTokenParam)->not->toBeNull()
-        ->and($authTokenParam->getType())->toBe('string')
-        ->and($authTokenParam->isNullable())->toBeFalse();
-});
+}

--- a/tests/Unit/Parsers/Helpers/TemplateHelperTest.php
+++ b/tests/Unit/Parsers/Helpers/TemplateHelperTest.php
@@ -1,0 +1,10 @@
+<?php
+
+
+use Crescat\SaloonSdkGenerator\Helpers\TemplateHelper;
+
+test('Render template', function () {
+    expect(TemplateHelper::render('This is a test'))->toBe('This is a test')
+        ->and(TemplateHelper::render('This is a {test}', ['test' => 'house']))->toBe('This is a house');
+
+});

--- a/tests/Unit/Parsers/OpenApiParserTest.php
+++ b/tests/Unit/Parsers/OpenApiParserTest.php
@@ -2,6 +2,18 @@
 
 use Crescat\SaloonSdkGenerator\Parsers\OpenApiParser;
 
+test('Parsed base url', function () {
+    $specFile = __DIR__ . '/../../Samples/bigcommerce/abandoned_carts.v3.yml';
+    $parser = OpenApiParser::build($specFile);
+    $spec = $parser->parse();
+
+    expect($spec->baseUrl->url)->toBe('https://api.bigcommerce.com/stores/{store_hash}/v3')
+        ->and($spec->baseUrl->parameters)->toHaveCount(1)
+        ->and($spec->baseUrl->parameters[0]->name)->toBe('store_hash')
+        ->and($spec->baseUrl->parameters[0]->default)->toBe('store_hash')
+        ->and($spec->baseUrl->parameters[0]->description)->toBe('Permanent ID of the BigCommerce store.');
+});
+
 test('Parsed security requirements', function () {
 
     $specFile = __DIR__ . '/../../Samples/bigcommerce/abandoned_carts.v3.yml';

--- a/tests/Unit/Parsers/OpenApiParserTest.php
+++ b/tests/Unit/Parsers/OpenApiParserTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Crescat\SaloonSdkGenerator\Parsers\OpenApiParser;
+
+test('Parsed security requirements', function () {
+
+    $specFile = __DIR__ . '/../../Samples/bigcommerce/abandoned_carts.v3.yml';
+    $parser = OpenApiParser::build($specFile);
+    $spec = $parser->parse();
+
+    expect($spec->securityRequirements)->toHaveCount(1)
+        ->and($spec->securityRequirements[0]->name)->toBe('X-Auth-Token');
+});
+
+test('Parsed components: security schemes', function () {
+
+    $specFile = __DIR__ . '/../../Samples/bigcommerce/abandoned_carts.v3.yml';
+    $parser = OpenApiParser::build($specFile);
+    $spec = $parser->parse();
+
+    expect($spec->components)->not()->toBeNull()
+        ->and($spec->components->securitySchemes)->toHaveCount(1)
+        ->and($spec->components->securitySchemes[0]->name)->toBe('X-Auth-Token')
+        ->and($spec->components->securitySchemes[0]->type)->toBe('apiKey')
+        ->and($spec->components->securitySchemes[0]->in)->toBe('header');
+});

--- a/tests/Unit/Parsers/PostmanCollectionParserTest.php
+++ b/tests/Unit/Parsers/PostmanCollectionParserTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Crescat\SaloonSdkGenerator\Parsers\PostmanCollectionParser;
+
+test('Parse collection', function () {
+    $specFile = __DIR__ . '/../../Samples/openai.json';
+    $parser = PostmanCollectionParser::build($specFile);
+    $spec = $parser->parse();
+
+    expect($spec->baseUrl->url)->toBe('https://api.openai.com/v1')
+        ->and($spec->name)->toBe('OpenAI')
+        ->and($spec->endpoints)->toHaveCount(28);
+
+    $endpoint = $spec->endpoints[0];
+    expect($endpoint->name)->toBe('List models')
+        ->and($endpoint->pathSegments)->toBe(['models'])
+        ->and($endpoint->method)->toBe(Crescat\SaloonSdkGenerator\Data\Generator\Method::GET);
+});


### PR DESCRIPTION
The goal of this change is to support API key as parameters to Connectors and declaring the authentication mechanism. Only API key authentication is supported at this time, e.g.

```
public function __construct(protected string $authToken) {
    $this->withTokenAuth($authToken);
}
```

I've added some unit tests for the OpenAPI parser and the ConnectorGenerator classes - just for the changed sections at this time. 

I had a decision to make during this what classes to create to capture the security schemes and requirements. I appreciate that you also support parsing Postman Collections which I'm less familiar with. Looking at their specification, they appear less comprehensive and less verbose than OpenAPI specs. I've chosen to align the the OpenAPI format as it's likely easier to convert postman to open API format than the other way around without losing fidelity of information.