### PR TITLE
fix: multi authenticator implementation generates invalid php

### DIFF
--- a/src/Generators/ConnectorGenerator.php
+++ b/src/Generators/ConnectorGenerator.php
@@ -252,11 +252,11 @@ class ConnectorGenerator extends Generator
                 $name = NameHelper::safeVariableName(preg_replace('/^X-/', '', $securityScheme->name));
                 switch ($securityScheme->in) {
                     case ApiKeyLocation::query:
-                        $authenticators[] = new Literal(sprintf('return new QueryAuthenticator("%s", $this->%s);', $securityScheme->name, $name));
+                        $authenticators[] = new Literal(sprintf('new QueryAuthenticator("%s", $this->%s)', $securityScheme->name, $name));
                         $namespace->addUse(QueryAuthenticator::class);
                         break;
                     case ApiKeyLocation::header:
-                        $authenticators[] = new Literal(sprintf('return new HeaderAuthenticator($this->%s, "%s");', $name, $securityScheme->name));
+                        $authenticators[] = new Literal(sprintf('new HeaderAuthenticator($this->%s, "%s")', $name, $securityScheme->name));
                         $namespace->addUse(HeaderAuthenticator::class);
                         break;
                     default:
@@ -268,27 +268,27 @@ class ConnectorGenerator extends Generator
             if ($securityScheme->type === SecuritySchemeType::http) {
                 switch ($securityScheme->scheme) {
                     case 'bearer':
-                        $authenticators[] = new Literal('return new TokenAuthenticator($this->bearerToken, "Bearer");');
+                        $authenticators[] = new Literal('new TokenAuthenticator($this->bearerToken, "Bearer")');
                         $namespace->addUse(TokenAuthenticator::class);
                         break;
                     case 'basic':
-                        $authenticators[] = new Literal('return new BasicAuthenticator($this->username, $this->password);');
+                        $authenticators[] = new Literal('new BasicAuthenticator($this->username, $this->password)');
                         $namespace->addUse(BasicAuthenticator::class);
                         break;
                     case 'digest':
                         // TODO: does this require you to provide a "digest" as well?
-                        $authenticators[] = new Literal('return new DigestAuthenticator($this->username, $this->password, "digest");');
+                        $authenticators[] = new Literal('new DigestAuthenticator($this->username, $this->password, "digest")');
                         $namespace->addUse(DigestAuthenticator::class);
                         break;
                     default:
-                        $authenticators[] = new Literal('return new TokenAuthenticator($this->token);');
+                        $authenticators[] = new Literal('new TokenAuthenticator($this->token)');
                         $namespace->addUse(TokenAuthenticator::class);
                         break;
                 }
             }
 
             if ($securityScheme->type === SecuritySchemeType::mutualTLS) {
-                $authenticators[] = new Literal('return new CertificateAuthenticator($this->certPath, $this->certPassword);');
+                $authenticators[] = new Literal('new CertificateAuthenticator($this->certPath, $this->certPassword)');
                 $namespace->addUse(CertificateAuthenticator::class);
             }
 
@@ -350,7 +350,7 @@ class ConnectorGenerator extends Generator
 
         // If there is only one authenticator, we can use it as the defaultAuth method.
         if (count($authenticators) === 1) {
-            $classType->addMethod('defaultAuth')->setReturnType(Authenticator::class)->setBody($authenticators[0]);
+            $classType->addMethod('defaultAuth')->setReturnType(Authenticator::class)->setBody(sprintf('return %s;', $authenticators[0]));
             $namespace->addUse(Authenticator::class);
         }
 

--- a/src/Generators/ConnectorGenerator.php
+++ b/src/Generators/ConnectorGenerator.php
@@ -356,13 +356,14 @@ class ConnectorGenerator extends Generator
 
         // If there are multiple authenticators, we need to use the MultiAuthenticator.
         if (count($authenticators) > 1) {
+            $namespace->addUse(MultiAuthenticator::class);
             $classType->addMethod('getAuthenticator')
                 ->setReturnType(MultiAuthenticator::class)
                 ->setBody(
                     new Literal(
                         sprintf(
-                            'return new MultiAuthenticator([%s]);',
-                            implode(', ', $authenticators)
+                            "return new MultiAuthenticator(\n\t%s\n);",
+                            implode(",\n\t", $authenticators)
                         )
                     )
                 );


### PR DESCRIPTION
This fixes the multiauthenticator which generates invalid php if more than one authenticator is generated.

will need to further dig into the tests of this project, so I may provide a corresponding test later. 

this is what the openapi spec contains:

![image](https://github.com/crescat-io/saloon-sdk-generator/assets/10237069/4844778d-5ab0-4f9c-b1ff-1b661ec8dfdb)

this is the output of the library currently:

![image](https://github.com/crescat-io/saloon-sdk-generator/assets/10237069/bc246f76-2eea-4794-bc06-f15157218f1d)

this is the output after the changes proposed in the PR:

![image](https://github.com/crescat-io/saloon-sdk-generator/assets/10237069/bb3c12de-21b7-4a82-a3fe-c8f7a6af9248)

